### PR TITLE
Metadata enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Apache Drill dialect for SQLAlchemy.
 ---
-The primary purpose of this is to have a working dialect for Apache Drill that can be used with Superset 
+The primary purpose of this is to have a working dialect for Apache Drill that can be used with Apache Superset.
 
-https://github.com/airbnb/superset
+https://superset.incubator.apache.org
 
 Obviously, a working, robust dialect for Drill serves other purposes as well, but most of the iterative planning for this REPO will be based on working with Caravel. Other changes will gladly be incorporated, as long as it doesn't hurt Superset integration. 
 
@@ -10,10 +10,9 @@ Obviously, a working, robust dialect for Drill serves other purposes as well, bu
 Currently we can connect to drill, and issue queries for basic visualizations and get results. We also ennumerate table columns for some times of tables. Here are things that are working as some larger issues to work out. (Individual issues are tracked under issues)
 
 * Connection to Drill via the databases tab in Superset succeeeds
-  * You need to specify schema in your connection string because caravel lists tables and will error if you don't have a default schema identified. Tracked in issue: https://github.com/JohnOmernik/sqlalchemy-drill/issues/4
   * Table lists in the connection for some reason only show the first two qualifiers of drill tables.  So if in the schema dfs.root you have two tables, table1 and table2, instead of showing table1 and table2 or dfs.root.table1 and dfs.root.table2, it will just show dfs.root and dfs.root.  This is tracked in issue: https://github.com/JohnOmernik/sqlalchemy-drill/issues/3
 * You can add tables under the tables menu
-  * Columns are listed properly from the table - However the their types are not all are returned as VARCHAR Tracked here: https://github.com/JohnOmernik/sqlalchemy-drill/issues/10
+  * Columns are listed properly from the table - 
 * You can do basic queries for certain types of viz/tables
   * More advanced queries/joins appear to have issues. As you learn about new ones, please track in issues
 
@@ -29,14 +28,13 @@ Right now all you need to do is python3 setup.py install this on the box you wil
 
 drill+sadrill://username:password@drillhost:drillport/dfs/yourdb?use_ssl=True
 
-I will update more later... sorry for the lack doc updates!
 
 
 
 ### Docker 
-Get the superset repo
-
+Get the superset repo and then in
+```
 FROM supersetimage(not sure it's name)
 RUN git clone https://github.com/JohnOmernik/sqlalchemy-drill && cd sqlalchemy-drill && python3 setup.py install 
 CMD["superset"]
-
+```

--- a/README.md
+++ b/README.md
@@ -4,32 +4,49 @@ The primary purpose of this is to have a working dialect for Apache Drill that c
 
 https://superset.incubator.apache.org
 
-Obviously, a working, robust dialect for Drill serves other purposes as well, but most of the iterative planning for this REPO will be based on working with Caravel. Other changes will gladly be incorporated, as long as it doesn't hurt Superset integration. 
+Obviously, a working, robust dialect for Drill serves other purposes as well, but most of the iterative planning for this REPO will be based on working with Superset. Other changes will gladly be incorporated, as long as it doesn't hurt Superset integration. 
+
+## Installation 
+Installing the dialect is straightforward.  Simply:
+1.  Clone or download this repository
+2.  Navigate to the directory where you cloned the repo
+3.  Run the python `setup.py` to install
+
+Examples are shown below
+```
+git clone https://github.com/JohnOmernik/sqlalchemy-drill
+cd sqlalchemy-drill
+python3 setup.py install 
+
+```
+
+## Usage
+To use Drill with SQLAlchemy you will need to craft a connection string in the format below:
+
+```
+drill+sadrill://<username>:<password>@<host>:<port>/<storage_plugin>?use_ssl=True
+```
+
+To connect to Drill running on a local machine running in embedded mode you can use the following connection string.  
+```
+drill+sadrill://localhost:8047/dfs?use_ssl=False
+```
+
+## Usage with Superset
+For a complete tutorial on how to use Superset with Drill, read the tutorial on @cgivre's blog available here: http://thedataist.com/visualize-anything-with-superset-and-drill/.
+
 
 ## Current Status/Development Approach
-Currently we can connect to drill, and issue queries for basic visualizations and get results. We also ennumerate table columns for some times of tables. Here are things that are working as some larger issues to work out. (Individual issues are tracked under issues)
+Currently we can connect to drill, and issue queries for most visualizations and get results. We also enumerate table columns for some times of tables. Here are things that are working as some larger issues to work out. (Individual issues are tracked under issues)
 
-* Connection to Drill via the databases tab in Superset succeeeds
+* Connection to Drill via the databases tab in Superset succeeds
   * Table lists in the connection for some reason only show the first two qualifiers of drill tables.  So if in the schema dfs.root you have two tables, table1 and table2, instead of showing table1 and table2 or dfs.root.table1 and dfs.root.table2, it will just show dfs.root and dfs.root.  This is tracked in issue: https://github.com/JohnOmernik/sqlalchemy-drill/issues/3
-* You can add tables under the tables menu
-  * Columns are listed properly from the table - 
-* You can do basic queries for certain types of viz/tables
-  * More advanced queries/joins appear to have issues. As you learn about new ones, please track in issues
-
-So, we are "limping along" and working as is, but contribution and just testing/use to identify issues would be very welcome! 
+* You can do basic queries for most types of viz/tables
+* There may be issues with advanced queries/joins. As you learn about new ones, please track in issues
 
 
 ### Many thanks
-to drillpy and pydrill for code used increating the drilldbapi.py code for connecting!
-
-# NOTE PLEASE READ
-Much of the this readme is wrong right now. I need to do updates
-Right now all you need to do is python3 setup.py install this on the box you will be runnign super set on then create a URL that looks like this:
-
-drill+sadrill://username:password@drillhost:drillport/dfs/yourdb?use_ssl=True
-
-
-
+to drillpy and pydrill for code used in creating the `drilldbapi.py` code for connecting!
 
 ### Docker 
 Get the superset repo and then in

--- a/sqlalchemy_drill/drilldbapi/_drilldbapi.py
+++ b/sqlalchemy_drill/drilldbapi/_drilldbapi.py
@@ -352,11 +352,9 @@ def connect(host, port=8047, db=None, use_ssl=False, drilluser=None, drillpass=N
             raise AuthError(str(raw_data), response.status_code)
 
         if db is not None:
-            #local_payload = api_globals._PAYLOAD.copy()
-            #local_url = "/query.json"
-            #local_payload["query"] = "USE {}".format(db)
-
-            default_storage_plugin = db
+            local_payload = api_globals._PAYLOAD.copy()
+            local_url = "/query.json"
+            local_payload["query"] = "USE {}".format(db)
 
             response = session.post(
                 "{proto}{host}:{port}{url}".format(proto=proto, host=host, port=str(port), url=local_url),

--- a/sqlalchemy_drill/sadrill.py
+++ b/sqlalchemy_drill/sadrill.py
@@ -4,7 +4,9 @@ from __future__ import unicode_literals
 from sqlalchemy import exc, pool, types
 from sqlalchemy.engine import default
 from sqlalchemy.sql import compiler
-from pandas.core.series import Series
+from sqlalchemy import inspect
+import requests
+from pprint import pprint
 
 try:
     from sqlalchemy.sql.compiler import SQLCompiler
@@ -56,6 +58,38 @@ class DrillIdentifierPreparer(compiler.IdentifierPreparer):
     def __init__(self, dialect):
         super(DrillIdentifierPreparer, self).__init__(dialect, initial_quote='`', final_quote='`')
 
+    def format_drill_table(self, schema, isFile=True):
+        formatted_schema = ""
+
+        num_dots = schema.count(".")
+        schema = schema.replace('`', '')
+
+        # For a file, the last section will be the file extension
+        schema_parts = schema.split('.')
+
+        if isFile and num_dots == 3:
+            # Case for File + Workspace
+            plugin = schema_parts[0]
+            workspace = schema_parts[1]
+            table = schema_parts[2] + "." + schema_parts[3]
+            formatted_schema = plugin + ".`" + workspace + "`.`" + table + "`"
+        elif isFile and num_dots == 2:
+            # Case for file and no workspace
+            plugin = schema_parts[0]
+            table = schema_parts[1] + "." + schema_parts[2]
+            formatted_schema = plugin + "`.`" + table + "`"
+        else:
+            # Case for non-file plugins or incomplete schema parts
+            for part in schema_parts:
+                quoted_part = "`" + part + "`"
+                if len(formatted_schema) > 0:
+                    formatted_schema += "." + quoted_part
+                else:
+                    formatted_schema = quoted_part
+
+        return formatted_schema
+
+
 
 try:
     from sqlalchemy.types import BigInteger
@@ -72,6 +106,7 @@ _type_map = {
     'decimal': types.DECIMAL,
     'double': types.FLOAT,
     'integer': types.INTEGER,
+    'INTEGER': types.INTEGER,
     'interval': types.Interval,
     'smallint': types.SMALLINT,
     'timestamp': types.TIMESTAMP,
@@ -116,11 +151,11 @@ class DrillCompiler_sadrill(compiler.SQLCompiler):
     def visit_tablesample(self, tablesample, asfrom=False, **kw):
         print(tablesample)
 
-
 class DrillDialect_sadrill(default.DefaultDialect):
 
     name = 'drilldbapi'
     driver = 'rest'
+    dbapi = ""
     preparer = DrillIdentifierPreparer
     statement_compiler = DrillCompiler_sadrill
     poolclass = pool.SingletonThreadPool
@@ -134,7 +169,13 @@ class DrillDialect_sadrill(default.DefaultDialect):
     description_encoding = None
     supports_native_boolean = True
     storage_plugin = ""
+    plugin_type = ""
+    supported_extensions = []
     workspace = ""
+    restURL = ""
+
+    def __init__(self, **kw):
+        default.DefaultDialect.__init__(self, **kw)
 
     @classmethod
     def dbapi(cls):
@@ -142,7 +183,7 @@ class DrillDialect_sadrill(default.DefaultDialect):
         return module
 
     def create_connect_args(self, url, **kwargs):
-        url_port = url.port or 8048
+        url_port = url.port or 8047
         qargs = {'host': url.host, 'port': url_port}
 
         try:
@@ -155,6 +196,14 @@ class DrillDialect_sadrill(default.DefaultDialect):
             self.username = url.username
             self.password = url.password
             self.db = db
+
+
+            # Get Storage Plugin Info:
+            if db_parts[0]:
+                self.storage_plugin = db_parts[0]
+
+            if len(db_parts) > 1:
+                self.workspace = db_parts[1]
 
             qargs.update(url.query)
             qargs['db'] = db
@@ -169,51 +218,32 @@ class DrillDialect_sadrill(default.DefaultDialect):
             print("************************************")
         return [], qargs
 
-    def get_selected_workspace(self):
-        return self.workspace
-
-    def get_selected_storage_plugin(self):
-        return self.storage_plugin
-
-    def has_table(self, connection, table_name, schema=None):
-        try:
-            self.get_columns(connection, table_name, schema)
-            return True
-        except exc.NoSuchTableError:
-            print("************************************")
-            print("Error in DrillDialect_sadrill.has_table :: ", exc.NoSuchTableError)
-            print("************************************")
-            return False
-
-    def get_view_names(self, connection, schema=None, **kw):
-        return []
+    def do_rollback(self, dbapi_connection):
+        # No transactions for Drill
+        pass
 
     def get_foreign_keys(self, connection, table_name, schema=None, **kw):
         """Drill has no support for foreign keys.  Returns an empty list."""
+        return []
+
+    def get_indexes(self, connection, table_name, schema=None, **kw):
+        """Drill has no support for indexes.  Returns an empty list. """
         return []
 
     def get_pk_constraint(self, connection, table_name, schema=None, **kw):
         """Drill has no support for primary keys.  Retunrs an empty list."""
         return []
 
-    def get_indexes(self, connection, table_name, schema=None, **kw):
-        """Drill has no support for indexes.  Returns an empty list. """
-        return[]
-
-    def do_rollback(self, dbapi_connection):
-        # No transactions for Drill
-        pass
-
-    def _check_unicode_returns(self, connection, additional_tests=None):
-        # requests gives back Unicode strings
-        return True
-
-    def _check_unicode_description(self, connection):
-        # requests gives back Unicode strings
-        return True
-
     def get_schema_names(self, connection, **kw):
-        curs = connection.execute("SHOW SCHEMAS")
+
+        # Get table information
+        # if self.storage_plugin:
+        #    query = "SELECT DISTINCT WORKSPACE_NAME AS SCHEMA_NAME FROM INFORMATION_SCHEMA.`FILES` WHERE SCHEMA_NAME LIKE '" + self.storage_plugin + "%'"
+        # else:
+
+        query = "SHOW DATABASES"
+
+        curs = connection.execute(query)
         result = []
         try:
             for row in curs:
@@ -226,44 +256,162 @@ class DrillDialect_sadrill(default.DefaultDialect):
 
         return tuple(result)
 
-    def get_table_names(self, connection, schema=None, **kw):
-        curs = connection.execute("SHOW FILES FROM {0}".format(self.db))
-        tables_names = []
-        try:
-            for row in curs:
-                if row.name.find(".view.drill") >= 0:
-                    myname = row.name.replace(".view.drill", "")
-                else:
-                    myname = row.name
-                tables_names.append(myname)
+    def get_selected_workspace(self):
+        return self.workspace
 
-        except Exception as ex:
+    def get_selected_storage_plugin(self):
+        return self.storage_plugin
+
+    def get_table_names(self, connection, schema=None, **kw):
+
+        if schema is not None:
+            quoted_schema = self.identifier_preparer.format_drill_table(schema)
+        else:
+            return
+
+        plugin_type = self.get_plugin_type(connection, quoted_schema)
+
+        print("Plugin Type: ", plugin_type)
+        self.plugin_type = plugin_type
+        self.quoted_schema = quoted_schema
+
+        if plugin_type == 'file':
+            curs = connection.execute("SHOW FILES FROM " + quoted_schema)
+            tables_names = []
+            try:
+                for row in curs:
+                    if row.name.find(".view.drill") >= 0:
+                        myname = row.name.replace(".view.drill", "")
+                    else:
+                        myname = row.name
+                    tables_names.append(myname)
+
+            except Exception as ex:
+                print("************************************")
+                print("Error in DrillDialect_sadrill.get_table_names :: ", str(ex))
+                print("************************************")
+            return tuple(tables_names)
+        else:
+            curs = connection.execute(
+                "SELECT `TABLE_NAME` AS name FROM INFORMATION_SCHEMA.`TABLES` WHERE `TABLE_SCHEMA` = '" + schema + "'")
+            tables_names = []
+            try:
+                for row in curs:
+                    if row.name.find(".view.drill") >= 0:
+                        myname = row.name.replace(".view.drill", "")
+                    else:
+                        myname = row.name
+                    tables_names.append(myname)
+
+            except Exception as ex:
+                print("************************************")
+                print("Error in DrillDialect_sadrill.get_table_names :: ", str(ex))
+                print("************************************")
+            return tuple(tables_names)
+
+    def get_view_names(self, connection, schema=None, **kw):
+        return []
+
+    def has_table(self, connection, table_name, schema=None):
+        try:
+            self.get_columns(connection, table_name, schema)
+            return True
+        except exc.NoSuchTableError:
             print("************************************")
-            print("Error in DrillDialect_sadrill.get_table_names :: ", str(ex))
+            print("Error in DrillDialect_sadrill.has_table :: ", exc.NoSuchTableError)
             print("************************************")
-        return tuple(tables_names)
+            return False
+
+    def _check_unicode_returns(self, connection, additional_tests=None):
+        # requests gives back Unicode strings
+        return True
+
+    def _check_unicode_description(self, connection):
+        # requests gives back Unicode strings
+        return True
+
+    def object_as_dict(obj):
+        return {c.key: getattr(obj, c.key)
+                for c in inspect(obj).mapper.column_attrs}
 
     def get_columns(self, connection, table_name, schema=None, **kw):
+
+        print("************************************")
+        print( "Schema: ", schema)
+        print( "Table Name: ", table_name)
+        print("************************************")
+
+
         result = []
-        if "SELECT " in table_name:
+
+        file_name = "`" + schema + "." + table_name + "`"
+        complete_file_name = self.storage_plugin + "." + self.workspace + "." + file_name
+
+        #q = "SELECT * FROM {file_name} LIMIT 1".format(file_name=complete_file_name)
+
+        if self.plugin_type == "file":
+            file_name = self.storage_plugin + "." + self.workspace + ".`" + schema + "." + table_name + "`"
+            q = "SELECT * FROM {file_name} LIMIT 1".format(file_name=file_name)
+        elif "SELECT " in table_name:
             q = "SELECT * FROM ({table_name}) LIMIT 1".format(table_name=table_name)
         else:
-            q = "DESCRIBE {table_name}".format(table_name=table_name)
+            quoted_schema  = self.identifier_preparer.format_drill_table(schema + "." + table_name, isFile=False)
+            q = "DESCRIBE {table_name}".format(table_name=quoted_schema)
 
-        cursor = connection.execute(q)
+        query_results = connection.execute(q).fetchall()
 
-        for col in cursor:
-            if len(col) > 0:
-                cname = col[1].get('Name', "")
-                dtype = str(col[1].get('dtype', 'ANY'))
-                ctype = _type_map.get(dtype, _type_map['ANY'])
-                bisnull = True
-                column = {
-                    "name": cname,
-                    "type": ctype,
-                    "default": None,
-                    "autoincrement": None,
-                    "nullable": bisnull,
-                }
-                result.append(column)
+        for row in query_results:
+            column = {
+                "name": row[0],
+                "type": _type_map[row[1]],
+                "longType": _type_map[row[1]]
+            }
+            result.append(column)
+
+        print(result)
         return result
+
+    def get_plugin_type(self, connection, plugin=None):
+
+        print( "Getting plugin type for: ", plugin)
+
+        if plugin is None:
+            return
+
+        plugin_type = ""
+
+        # Clean up plugin
+        if plugin.count('.') >= 1:
+            plugin = plugin.replace('`','')
+            plugin_parts = plugin.split('.')
+            plugin = plugin_parts[0]
+
+        url = "http://" + self.host + ":" + str(self.port) + "/storage/" + plugin + ".json"
+        print( "Plugin URL:", url)
+        # This check is necessary to determine whether the connection has been created or not
+        if hasattr(connection, 'url'):
+            #self.create_connect_args(connection.url)
+
+            try:
+                # TODO Support SSL
+                r = requests.get(url)
+                json_result = r.json()
+
+                plugin_type = json_result['config']['type']
+                self.plugin_type = plugin_type
+
+                if self.plugin_type == "file":
+                    formats = json_result['config']['formats']
+                    for format in formats.keys():
+                        self.supported_extensions.append(format)
+
+                return plugin_type
+
+            except Exception as ex:
+                print("************************************")
+                print("Error in DrillDialect_sadrill.get_plugin_type :: ", str(ex))
+                print("************************************")
+                return False
+        else:
+            return
+

--- a/sqlalchemy_drill/sadrill.py
+++ b/sqlalchemy_drill/sadrill.py
@@ -100,22 +100,32 @@ _type_map = {
     'bigint': types.BIGINT,
     'BIGINT': types.BIGINT,
     'binary': types.LargeBinary,
+    'BINARY': types.LargeBinary,
     'boolean': types.BOOLEAN,
+    'BOOLEAN': types.BOOLEAN,
     'date': types.DATE,
     'DATE': types.DATE,
     'decimal': types.DECIMAL,
+    'DECIMAL': types.DECIMAL,
     'double': types.FLOAT,
+    'DOUBLE': types.FLOAT,
     'integer': types.INTEGER,
     'INTEGER': types.INTEGER,
     'interval': types.Interval,
+    'INTERVAL': types.Interval,
     'smallint': types.SMALLINT,
+    'SMALLINT': types.SMALLINT,
     'timestamp': types.TIMESTAMP,
     'TIMESTAMP': types.TIMESTAMP,
     'time': types.TIME,
+    'TIME': types.TIME,
     'varchar': types.String,
     'VARCHAR': types.String,
+    'character varying': types.String,
     'CHARACTER VARYING': types.String,
-    'ANY': types.String
+    'ANY': types.String,
+    'any': types.String
+
 }
 
 
@@ -256,12 +266,14 @@ class DrillDialect_sadrill(default.DefaultDialect):
         return self.storage_plugin
 
     def get_table_names(self, connection, schema=None, **kw):
+        if schema is None:
+            schema = connection.engine.url.database
+        # Clean up schema
 
-        if schema is not None:
-            quoted_schema = self.identifier_preparer.format_drill_table(schema)
-        else:
-            return
+        quoted_schema = self.identifier_preparer.format_drill_table(schema)
+        quoted_schema = quoted_schema.replace("/", ".")
 
+        # https://docs.sqlalchemy.org/en/latest/core/connections.html#translation-of-schema-names
         plugin_type = self.get_plugin_type(connection, quoted_schema)
 
         self.plugin_type = plugin_type
@@ -344,8 +356,8 @@ class DrillDialect_sadrill(default.DefaultDialect):
             for row in column_metadata:
                 column = {
                     "name": row[0],
-                    "type": _type_map[row[1]],
-                    "longtype": _type_map[row[1]]
+                    "type": _type_map[row[1].lower()],
+                    "longtype": _type_map[row[1].lower()]
                 }
                 result.append(column)
 
@@ -362,8 +374,8 @@ class DrillDialect_sadrill(default.DefaultDialect):
         for row in query_results:
             column = {
                 "name": row[0],
-                "type": _type_map[row[1]],
-                "longType": _type_map[row[1]]
+                "type": _type_map[row[1].lower()],
+                "longType": _type_map[row[1].lower()]
             }
             result.append(column)
         return result

--- a/sqlalchemy_drill/sadrill.py
+++ b/sqlalchemy_drill/sadrill.py
@@ -109,6 +109,8 @@ _type_map = {
     'DECIMAL': types.DECIMAL,
     'double': types.FLOAT,
     'DOUBLE': types.FLOAT,
+    'int': types.INTEGER,
+    'INT': types.INTEGER,
     'integer': types.INTEGER,
     'INTEGER': types.INTEGER,
     'interval': types.Interval,


### PR DESCRIPTION
This PR adds a lot of functionality to superset.   As of Drill 1.15, Drill includes column metadata in the REST interface as well as improvements to the `INFORMATION_SCHEMA`.  The specific improvements allow you to use SQL Lab in Superset.  See images below:

## Picking a Storage Plugin
In SQL Lab you can pick from the available and enabled storage plugins:
<img width="384" alt="screen shot 2019-01-07 at 14 41 22" src="https://user-images.githubusercontent.com/5513150/50789456-560d2680-128a-11e9-8ab0-d5b01e3a990d.png">

## Select a File or Schema
Once you've selected the schema, Superset will load the available files and populate the dropdown menu.
<img width="362" alt="screen shot 2019-01-07 at 14 47 28" src="https://user-images.githubusercontent.com/5513150/50789844-44784e80-128b-11e9-9cfd-4c5a58592a6a.png">

Once you've done that, you can see that Superset will read the columns and their associated data types as shown in the image below:
<img width="344" alt="screen shot 2019-01-07 at 14 48 40" src="https://user-images.githubusercontent.com/5513150/50789881-6376e080-128b-11e9-928d-c8a4b3c76cc6.png">

Additionally, you can preview the file or table structure:
<img width="938" alt="screen shot 2019-01-07 at 14 51 01" src="https://user-images.githubusercontent.com/5513150/50790001-b6509800-128b-11e9-9e96-81bbd1080b71.png">

Not only that, but it enables type ahead!!
<img width="525" alt="screen shot 2019-01-07 at 14 51 16" src="https://user-images.githubusercontent.com/5513150/50790015-bf416980-128b-11e9-82ed-c547f65234c6.png">



