### PR TITLE
fix extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(name='sqlalchemy_drill',
           "sqlalchemy"
       ],
       extras_require={
-            "jdbc": ["JPype1==0.6.3, JayDeBeApi"]
+          "jdbc": ["JPype1==0.6.3", "JayDeBeApi"]
       },
       keywords='SQLAlchemy Apache Drill',
       author='John Omernik, Charles Givre, Davide Miceli, Massimo Martiradonna',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(name='sqlalchemy_drill',
           "sqlalchemy"
       ],
       extras_require={
-            "jdbc": ["jpype=0.6.3, JayDeBeApi"]
+            "jdbc": ["JPype1==0.6.3, JayDeBeApi"]
       },
       keywords='SQLAlchemy Apache Drill',
       author='John Omernik, Charles Givre, Davide Miceli, Massimo Martiradonna',


### PR DESCRIPTION
fixing the installation error

> error in sqlalchemy_drill setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.