### PR TITLE
Add pyodbc backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,32 @@ For a simple installation, this might look like:
 drill+jdbc://admin:password@localhost:31010
 ```
 
+## Usage with ODBC
+In order to configure SQLAlchemy to work with Drill via ODBC you must:
+* Install latest Drill ODBC Driver: https://drill.apache.org/docs/installing-the-driver-on-linux/
+* Ensure that you have ODBC support in your system (`unixODBC` package for RedHat-based systems).
+* Install `pyodbc` Python package.  
+  This module is listed as an optional dependency and will not be installed by the default installer.
+
+To connect to Drill with SQLAlchemy use the following connection string:
+```
+drill+odbc:///?<ODBC connection parameters>
+```
+
+Connection properties are available in the official documentation: https://drill.apache.org/docs/odbc-configuration-reference/
+
+For a simple installation, this might look like:
+```
+drill+odbc:///?Driver=/opt/mapr/drill/lib/64/libdrillodbc_sb64.so&ConnectionType=Direct&HOST=localhost&PORT=31010&AuthenticationType=Plain&UID=admin&PWD=password
+```
+or for the case when you have DSN configured in `odbc.ini`:
+```
+drill+odbc:///?DSN=drill_dsn_name
+```
+
+**Note:** it's better to avoid using connection string with `hostname:port` or `username`/`password`, like 'drill+odbc://admin:password@localhost:31010/' but use only ODBC properties instead to avoid any misinterpretation between these parameters.
+
+
 ## Usage with Superset
 For a complete tutorial on how to use Superset with Drill, read the tutorial on @cgivre's blog available here: http://thedataist.com/visualize-anything-with-superset-and-drill/.
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,3 +1,4 @@
 sqlalchemy
 pydrill
 JayDeBeApi
+pyodbc

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(name='sqlalchemy_drill',
           "sqlalchemy"
       ],
       extras_require={
-          "jdbc": ["JPype1==0.6.3", "JayDeBeApi"]
+          "jdbc": ["JPype1==0.6.3", "JayDeBeApi"],
+          "odbc": ["pyodbc"],
       },
       keywords='SQLAlchemy Apache Drill',
       author='John Omernik, Charles Givre, Davide Miceli, Massimo Martiradonna',
@@ -57,6 +58,8 @@ setup(name='sqlalchemy_drill',
           'sqlalchemy.dialects': [
               'drill = sqlalchemy_drill.sadrill:DrillDialect_sadrill',
               'drill.sadrill = sqlalchemy_drill.sadrill:DrillDialect_sadrill',
+              'drill.jdbc = sqlalchemy_drill.jdbc:DrillDialect_jdbc',
+              'drill.odbc = sqlalchemy_drill.odbc:DrillDialect_odbc',
           ]
       }
     )

--- a/test/test_odbc.ini
+++ b/test/test_odbc.ini
@@ -1,0 +1,8 @@
+[test DSN]
+Driver=/opt/mapr/drill/lib/64/libdrillodbc_sb64.so
+ConnectionType=Direct
+HOST=localhost
+PORT=31010
+AuthenticationType=Plain
+UID=admin
+PWD=password

--- a/test/test_odbc.py
+++ b/test/test_odbc.py
@@ -19,12 +19,36 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = '0.9'
-from sqlalchemy.dialects import registry
+import os
 
-registry.register("drill", "sqlalchemy_drill.sadrill", "DrillDialect_sadrill")
-registry.register("drill.sadrill", "sqlalchemy_drill.sadrill", "DrillDialect_sadrill")
+from sqlalchemy import create_engine
 
-registry.register("drill.jdbc", "sqlalchemy_drill.jdbc", "DrillDialect_jdbc")
 
-registry.register("drill.odbc", "sqlalchemy_drill.odbc", "DrillDialect_odbc")
+print('Using ODBC connection string:')
+
+engine = create_engine('drill+odbc:///?'
+                       'Driver=/opt/mapr/drill/lib/64/libdrillodbc_sb64.so&'
+                       'ConnectionType=Direct&'
+                       'HOST=localhost&'
+                       'PORT=31010&'
+                       'AuthenticationType=Plain&'
+                       'UID=admin&'
+                       'PWD=password&'
+                       )
+
+with engine.connect() as con:
+    rs = con.execute('SELECT * FROM cp.`employee.json` LIMIT 5')
+    for row in rs:
+        print(row)
+
+
+print('Using DSN:')
+
+os.environ['ODBCINI'] = os.path.join(os.path.dirname(__file__), 'test_odbc.ini')
+
+engine = create_engine('drill+odbc:///?DSN=test DSN')
+
+with engine.connect() as con:
+    rs = con.execute('SELECT * FROM cp.`employee.json` LIMIT 5')
+    for row in rs:
+        print(row)


### PR DESCRIPTION
Here's an ability to connect to Drill via ODBC using `pyodbc` module.

I've decided not to convert `username` and `password` parameters returned from `create_connect_args` to `UID` and `PWD` respectively and in general not to convert URL parameters (`username:password@hostname:port`) to valid Drill ODBC properties to prevent any misinterpretation of parameters in connection strings like `drill+odbc://myName:myPWD@localhost:31010/?UID=notMyName`.
And I've added note on this in README.md.
But I can implement it, if you find it useful.

**Testing done**
I was able to run `python test/test_odbc.py` successfully on CentOS/Ubuntu machines. Drill was configured to authenticate users with PAM and SSL was disabled, plus I've created user `admin` with password `password` on machine with Drill server . Also, I was able to connect from Python shell to Drill with MapRSASL.