### PR TITLE
Use Drill metadata to map returned data to Pandas dtypes

### DIFF
--- a/sqlalchemy_drill/drilldbapi/_drilldbapi.py
+++ b/sqlalchemy_drill/drilldbapi/_drilldbapi.py
@@ -174,13 +174,13 @@ class Cursor(object):
                     # Pandas < 1.0.0 cannot handle null ints so we sometimes cannot cast to an int dtype
                     can_cast = True
 
-                    if col_name == 'BIT':
+                    if col_drill_type == 'BIT':
                         df[col_name] = df[col_name] == 'true'
-                    elif col_name == 'TIME': # col_name in ['TIME', 'INTERVAL']: # parsing of ISO-8601 intervals appears broken as of Pandas 1.0.3
+                    elif col_drill_type == 'TIME': # col_name in ['TIME', 'INTERVAL']: # parsing of ISO-8601 intervals appears broken as of Pandas 1.0.3
                         df[col_name] = pd.to_timedelta(df[col_name])
-                    elif col_name in ['FLOAT4', 'FLOAT8']:
+                    elif col_drill_type in ['FLOAT4', 'FLOAT8']:
                         df[col_name] = pd.to_numeric(df[col_name])
-                    elif col_name in ['BIGINT', 'INT', 'SMALLINT']:
+                    elif col_drill_type in ['BIGINT', 'INT', 'SMALLINT']:
                         df[col_name] = pd.to_numeric(df[col_name])
                         if pd.__version__ < '1' and df[col_name].isnull().values.any():
                             logger.warn('Column {} of Drill type {} contains nulls so cannot be converted to an integer dtype in Pandas < 1.0.0'.format(col_name, col_drill_type))

--- a/sqlalchemy_drill/drilldbapi/_drilldbapi.py
+++ b/sqlalchemy_drill/drilldbapi/_drilldbapi.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from json import dumps
-from pandas import DataFrame
+import pandas as pd
 from requests import Session
 import re
 import logging
@@ -13,6 +13,22 @@ threadsafety = 3
 paramstyle = 'qmark'
 default_storage_plugin = ""
 
+DRILL_PANDAS_TYPE_MAP = {
+        'BIGINT': 'int64',
+        'BINARY': 'object',
+        'BIT':  'boolean', # handled as a special case
+        'DATE': 'datetime64[ns]',
+        'FLOAT4': 'float32',
+        'FLOAT8': 'float64',
+        'INT': 'int32',
+        'INTERVALDAY': 'string' if pd.__version__ >= '1' else 'object',
+        'INTERVALYEAR': 'string' if pd.__version__ >= '1' else 'object',
+        'SMALLINT': 'int32',
+        'TIME': 'timedelta64[ns]' # handled as a special case,
+        'TIMESTAMP': 'datetime64[ns]',
+        'VARDECIMAL': 'object',
+        'VARCHAR' : 'string' if pd.__version__ >= '1' else 'object'
+        }
 
 logging.basicConfig(level=logging.WARN)
 logging.basicConfig(format='%(name)s - %(levelname)s - %(message)s')
@@ -111,7 +127,7 @@ class Cursor(object):
         print("Query:", operation)
         print("************************************")
 
-        matchObj = re.match('^SHOW FILES FROM\s(.+)', operation, re.IGNORECASE)
+        matchObj = re.match(r'^SHOW FILES FROM\s(.+)', operation, re.IGNORECASE)
         if matchObj:
             self.default_storage_plugin = matchObj.group(1)
 
@@ -121,15 +137,9 @@ class Cursor(object):
             print("************************************")
             raise ProgrammingError(result.json().get("errorMessage", "ERROR"), result.status_code)
         else:
-            self._resultSet = (
-                DataFrame(
-                    result.json()["rows"],
-                    columns=result.json()["columns"]
-                )
-            )
-
-            cols = result.json()["columns"]
-            metadata = result.json()["metadata"]
+            result_json = result.json()
+            cols = result_json["columns"]
+            metadata = result_json["metadata"]
 
             # Get column metadata
             column_metadata = []
@@ -141,6 +151,31 @@ class Cursor(object):
                 column_metadata.append(col)
 
             self._resultSetMetadata = column_metadata
+
+            df = pd.DataFrame(result_json["rows"], columns=result_json["columns"])
+
+            # The columns in df all have a dtype of object because Drill's
+            # HTTP API always quotes the values in the JSON it returns, thereby
+            # providing DataFrame(...) with a dict of strings.  We now use
+            # the metadata returned by Drill to correct this
+            for i in range(len(cols)):
+                # strip any precision information that might be in the metdata e.g. VARCHAR(10)
+                m = re.sub(r'\(.*\)', '', metadata[i])
+
+                if m in DRILL_PANDAS_TYPE_MAP:
+                    if m == 'BIT':
+                        df[cols[i]] = df[cols[i]] == 'true'
+                    elif m == 'TIME': # m in ['TIME', 'INTERVAL']: # parsing of ISO-8601 intervals appears broken as of Pandas 1.0.3
+                        df[cols[i]] = pd.to_timedelta(df[cols[i]])
+                    else:
+                        df[cols[i]] = df[cols[i]].astype(DRILL_PANDAS_TYPE_MAP[m])
+                else:
+                    print("************************************")
+                    print("Warning: could not map Drill column {} of type {} to a Pandas dtype".format(cols[i], m))
+                    print("************************************")
+
+            self._resultSet = ( df )
+
             self.rowcount = len(self._resultSet)
             self._resultSetStatus = iter(range(len(self._resultSet)))
             column_names, column_types = self.parse_column_types(self._resultSetMetadata)
@@ -170,7 +205,7 @@ class Cursor(object):
             return self._resultSet.iloc[next(self._resultSetStatus)]
         except StopIteration:
             print("************************************")
-            print("Catched StopIteration in fetchone")
+            print("Caught StopIteration in fetchone")
             print("************************************")
             # We need to put None rather than Series([]) because
             # SQLAlchemy processes that a row with no columns which it doesn't like
@@ -196,7 +231,7 @@ class Cursor(object):
             return [tuple(x) for x in myresults.to_records(index=False)]
         except StopIteration:
             print("************************************")
-            print("Catched StopIteration in fetchmany")
+            print("Caught StopIteration in fetchmany")
             print("************************************")
             return None
 
@@ -210,7 +245,7 @@ class Cursor(object):
 
         except StopIteration:
             print("************************************")
-            print("Catched StopIteration in fetchall")
+            print("Caught StopIteration in fetchall")
             print("************************************")
             return None
 

--- a/sqlalchemy_drill/drilldbapi/_drilldbapi.py
+++ b/sqlalchemy_drill/drilldbapi/_drilldbapi.py
@@ -14,17 +14,17 @@ paramstyle = 'qmark'
 default_storage_plugin = ""
 
 DRILL_PANDAS_TYPE_MAP = {
-        'BIGINT': 'int64',
+        'BIGINT': 'Int64',
         'BINARY': 'object',
-        'BIT':  'boolean', # handled as a special case
+        'BIT':  'boolean',
         'DATE': 'datetime64[ns]',
         'FLOAT4': 'float32',
         'FLOAT8': 'float64',
-        'INT': 'int32',
+        'INT': 'Int32',
         'INTERVALDAY': 'string' if pd.__version__ >= '1' else 'object',
         'INTERVALYEAR': 'string' if pd.__version__ >= '1' else 'object',
-        'SMALLINT': 'int32',
-        'TIME': 'timedelta64[ns]' # handled as a special case,
+        'SMALLINT': 'Int32',
+        'TIME': 'timedelta64[ns]',
         'TIMESTAMP': 'datetime64[ns]',
         'VARDECIMAL': 'object',
         'VARCHAR' : 'string' if pd.__version__ >= '1' else 'object'
@@ -164,11 +164,13 @@ class Cursor(object):
 
                 if m in DRILL_PANDAS_TYPE_MAP:
                     if m == 'BIT':
-                        df[cols[i]] = df[cols[i]] == 'true'
+                        df[self.columns[i]] = df[self.columns[i]] == 'true'
                     elif m == 'TIME': # m in ['TIME', 'INTERVAL']: # parsing of ISO-8601 intervals appears broken as of Pandas 1.0.3
-                        df[cols[i]] = pd.to_timedelta(df[cols[i]])
-                    else:
-                        df[cols[i]] = df[cols[i]].astype(DRILL_PANDAS_TYPE_MAP[m])
+                        df[self.columns[i]] = pd.to_timedelta(df[self.columns[i]])
+                    elif m in ['BIGINT', 'FLOAT4', 'FLOAT8', 'INT', 'SMALLINT']:
+                        df[self.columns[i]] = pd.to_numeric(df[self.columns[i]])
+
+                    df[self.columns[i]] = df[self.columns[i]].astype(DRILL_PANDAS_TYPE_MAP[m])
                 else:
                     print("************************************")
                     print("Warning: could not map Drill column {} of type {} to a Pandas dtype".format(cols[i], m))


### PR DESCRIPTION
Data fetched using the Drill HTTP API are always handled as strings.  This PR uses the metadata returned in the Drill HTTP response to map the returned data to Pandas dtypes as best it can.  There are also a couple of unrelated but entirely trivial lint and grammar touch ups.

### Results:
```
pd.read_sql_query("""
select 
  current_date `date`,
  current_time `time`,
  current_timestamp `timestamp`,
  1=1 as `boolean`,
  'foobar' as `varchar`,
  cast(2 as int) `int`,
  cast(2 as bigint) `bigint`,
  cast(2 as float) `float`,
  cast(2 as double) `double`,
  interval '2' day `interval`
""", engine).info()

<class 'pandas.core.frame.DataFrame'>
RangeIndex: 1 entries, 0 to 0
Data columns (total 10 columns):
 #   Column     Non-Null Count  Dtype          
---  ------     --------------  -----          
 0   date       1 non-null      datetime64[ns] 
 1   time       1 non-null      timedelta64[ns]
 2   timestamp  1 non-null      datetime64[ns] 
 3   boolean    1 non-null      bool           
 4   varchar    1 non-null      object         
 5   int        1 non-null      int64          
 6   bigint     1 non-null      int64          
 7   float      1 non-null      float64        
 8   double     1 non-null      float64        
 9   interval   1 non-null      object         
dtypes: bool(1), datetime64[ns](2), float64(2), int64(2), object(2), timedelta64[ns](1)
memory usage: 201.0+ bytes
```