### PR TITLE
Fixed Error with Drill Arrays

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='sqlalchemy_drill',
-      version='0.2.1',
+      version='0.2.2',
       description="Apache Drill for SQLAlchemy",
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
A recent PR which attempted to map Drill data types introduced many errors including this one in which caused an error when Drill returned an array.  The metadata Drill returned would indicate the primitive type of the array, however, when Pandas attempted to parse something like `[1,2,3]` as an `INT` it would clearly break that.  

This PR also coverts some of the `print()` statements to `logging.debug()`