### PR TITLE
Parse floats with errors='coerce' in drilldbapi to handle 'NaN'

### DIFF
--- a/sqlalchemy_drill/drilldbapi/_drilldbapi.py
+++ b/sqlalchemy_drill/drilldbapi/_drilldbapi.py
@@ -16,7 +16,7 @@ default_storage_plugin = ""
 DRILL_PANDAS_TYPE_MAP = {
         'BIGINT': 'Int64',
         'BINARY': 'object',
-        'BIT':  'bool',
+        'BIT':  'boolean' if pd.__version__ >= '1' else 'bool',
         'DATE': 'datetime64[ns]',
         'FLOAT4': 'float32',
         'FLOAT8': 'float64',
@@ -168,7 +168,9 @@ class Cursor(object):
                         can_cast = True
 
                         if col_drill_type == 'BIT':
-                            df[col_name] = df[col_name] == 'true'
+                            if pd.__version__ < '1' and df[col_name].isna().any():
+                                logger.warn('Null boolean values will be coerced to False!  Upgrade to Pandas >= 1.0 for nullable booleans.')
+                            df[col_name] = df[col_name].apply(lambda b: b == 'true' if b else None)
                         # Commenting this out for the time being. Pandas does not seem to support time data types (times with no dates) and hence
                         # this functionality breaks Superset. 
                         #elif col_drill_type == 'TIME': # col_name in ['TIME', 'INTERVAL']: # parsing of ISO-8601 intervals appears broken as of Pandas 1.0.3

--- a/sqlalchemy_drill/drilldbapi/_drilldbapi.py
+++ b/sqlalchemy_drill/drilldbapi/_drilldbapi.py
@@ -176,7 +176,8 @@ class Cursor(object):
                             #df[col_name] = pd.to_timedelta(df[col_name])
                             #df[col_name] = pd.to_datetime()
                         elif col_drill_type in ['FLOAT4', 'FLOAT8']:
-                            df[col_name] = pd.to_numeric(df[col_name])
+                            # coerce errors when parsing floats to handle 'NaN' ('Infinity' is fine)
+                            df[col_name] = pd.to_numeric(df[col_name], errors='coerce')
                         elif col_drill_type in ['BIGINT', 'INT', 'SMALLINT']:
                             df[col_name] = pd.to_numeric(df[col_name])
                             if df[col_name].isnull().values.any():


### PR DESCRIPTION
Drill may return 'NaN', 'Infinity' or '-Infinity' for floats.  The
to_numeric method in Pandas correctly deals with all but the first.
However, when to_numeric is called with errors='coerce' then 'NaN' will be
mapped to floating point NaN.

This should not affect the handling of genuinely invalid float strings for anyone because this code path only runs when Drill's metadata indicates a column of type FLOAT4 or FLOAT8, and that precludes the presence of invalid float strings.