### PR TITLE
bugfix: resolve empty df mapping error

### DIFF
--- a/sqlalchemy_drill/drilldbapi/_drilldbapi.py
+++ b/sqlalchemy_drill/drilldbapi/_drilldbapi.py
@@ -160,7 +160,7 @@ class Cursor(object):
                     logging.debug('Mapping column {} of Drill type {} to dtype {}'.format(col_name, col_drill_type, col_dtype))
 
                     # Null values cause problems, so first verify if there are null values in the column
-                    if df[col_name].isnull().values.any():
+                    if df[col_name].isnull().values.any() or df.size == 0:
                         can_cast = False
                     elif str(df[col_name].iloc[0]).startswith("[") and str(df[col_name].iloc[0]).endswith("]"):
                         can_cast = False


### PR DESCRIPTION
This PR resolve drill mongo connection mapping error below. 
I checked the erroneous df and realized it has 0 row. Thats why I added extra check and problem solved. 

```
superset_1  | DEBUG:root:Mapping column TABLE_NAME of Drill type VARCHAR to dtype string
superset_1  | ERROR:root:module 'sqlalchemy_drill.drilldbapi' has no attribute 'Error'
superset_1  | Traceback (most recent call last):
superset_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1277, in _execute_context
superset_1  |     cursor, statement, parameters, context
superset_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 593, in do_execute
superset_1  |     cursor.execute(statement, parameters)
superset_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy_drill/drilldbapi/_drilldbapi.py", line 65, in func_wrapper
superset_1  |     return func(self, *args, **kwargs)
superset_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy_drill/drilldbapi/_drilldbapi.py", line 167, in execute
superset_1  |     elif str(df[col_name].iloc[0]).startswith("[") and str(df[col_name].iloc[0]).endswith("]"):
superset_1  |   File "/usr/local/lib/python3.7/site-packages/pandas/core/indexing.py", line 879, in __getitem__
superset_1  |     return self._getitem_axis(maybe_callable, axis=axis)
superset_1  |   File "/usr/local/lib/python3.7/site-packages/pandas/core/indexing.py", line 1496, in _getitem_axis
superset_1  |     self._validate_integer(key, axis)
superset_1  |   File "/usr/local/lib/python3.7/site-packages/pandas/core/indexing.py", line 1437, in _validate_integer
superset_1  |     raise IndexError("single positional indexer is out-of-bounds")
superset_1  | IndexError: single positional indexer is out-of-bounds
```
Resolves #61 and apache/superset#12155
