### PR TITLE
Fix no attribute 'Error'

### DIFF
--- a/sqlalchemy_drill/drilldbapi/__init__.py
+++ b/sqlalchemy_drill/drilldbapi/__init__.py
@@ -1,2 +1,2 @@
 from ._drilldbapi import *
-
+from .api_exceptions import *


### PR DESCRIPTION
Fix: error module 'sqlalchemy_drill.drilldbapi' has no attribute 'Error'