### PR TITLE
1.1.0 - Rewrite the Drill DB-API implementation using ijson

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='sqlalchemy_drill',
-      version='1.0.0',
+      version='1.1.0',
       description="Apache Drill for SQLAlchemy",
       long_description=long_description,
       long_description_content_type="text/markdown",
@@ -49,8 +49,7 @@ setup(name='sqlalchemy_drill',
       ],
       install_requires=[
           "requests",
-          "numpy",
-          "pandas",
+          "ijson",
           "sqlalchemy"
       ],
       extras_require={
@@ -58,11 +57,14 @@ setup(name='sqlalchemy_drill',
           "odbc": ["pyodbc"],
       },
       keywords='SQLAlchemy Apache Drill',
-      author='John Omernik, Charles Givre, Davide Miceli, Massimo Martiradonna',
-      author_email='john@omernik.com, cgivre@thedataist.com, davide.miceli.dap@gmail.com, massimo.martiradonna.dap@gmail.com',
+      author='John Omernik, Charles Givre, Davide Miceli, Massimo Martiradonna'
+      ', James Turton',
+      author_email='john@omernik.com, cgivre@thedataist.com, davide.miceli.dap'
+      '@gmail.com, massimo.martiradonna.dap@gmail.com, james@somecomputer.xyz',
       license='MIT',
-      url = 'https://github.com/JohnOmernik/sqlalchemy-drill',
-      download_url = 'https://github.com/JohnOmernik/sqlalchemy-drill/archive/1.0.0.tar.gz',
+      url='https://github.com/JohnOmernik/sqlalchemy-drill',
+      download_url='https://github.com/JohnOmernik/sqlalchemy-drill/archive/'
+      '1.1.0.tar.gz',
       packages=find_packages(),
       include_package_data=True,
       tests_require=['nose >= 0.11'],
@@ -76,4 +78,4 @@ setup(name='sqlalchemy_drill',
               'drill.odbc = sqlalchemy_drill.odbc:DrillDialect_odbc',
           ]
       }
-    )
+      )

--- a/sqlalchemy_drill/__init__.py
+++ b/sqlalchemy_drill/__init__.py
@@ -19,7 +19,7 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 from sqlalchemy.dialects import registry
 
 registry.register("drill", "sqlalchemy_drill.sadrill", "DrillDialect_sadrill")

--- a/sqlalchemy_drill/drilldbapi/api_globals.py
+++ b/sqlalchemy_drill/drilldbapi/api_globals.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 # Global variables
-_HEADER = {"Content-Type": "application/json"}
-_PAYLOAD = {"queryType": "SQL", "query": None}
-_LOGIN = {"j_username": None, "j_password": None}
+_HEADER = {'Content-Type': 'application/json'}
+_PAYLOAD = {'queryType': 'SQL', 'query': None}
+_LOGIN = {'j_username': None, 'j_password': None}
+_PROGRESS_LOG_N = 10_000
+

--- a/sqlalchemy_drill/sadrill.py
+++ b/sqlalchemy_drill/sadrill.py
@@ -4,7 +4,7 @@
 # SQLAlchemy is a trademark of Michael Bayer.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this
-# software and associated documentation files (the "Software"), to deal in the Software
+# software and associated documentation files (the 'Software'), to deal in the Software
 # without restriction, including without limitation the rights to use, copy, modify, merge,
 # publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons
 # to whom the Software is furnished to do so, subject to the following conditions:
@@ -12,7 +12,7 @@
 # The above copyright notice and this permission notice shall be included in all copies or
 # substantial portions of the Software.
 
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
 # PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
 # FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
@@ -26,6 +26,9 @@ from __future__ import unicode_literals
 from sqlalchemy import pool
 from sqlalchemy.engine import default
 from .base import DrillDialect, DrillIdentifierPreparer, DrillCompiler_sadrill
+import logging
+
+logger = logging.getLogger('sadrill')
 
 try:
     from sqlalchemy.sql.compiler import SQLCompiler
@@ -38,11 +41,12 @@ try:
 except ImportError:
     from sqlalchemy.databases.mysql import MSBigInteger as BigInteger
 
+
 class DrillDialect_sadrill(DrillDialect):
 
     name = 'drilldbapi'
     driver = 'rest'
-    dbapi = ""
+    dbapi = ''
     preparer = DrillIdentifierPreparer
     statement_compiler = DrillCompiler_sadrill
     poolclass = pool.SingletonThreadPool
@@ -71,7 +75,7 @@ class DrillDialect_sadrill(DrillDialect):
 
         try:
             db_parts = (url.database or 'drill').split('/')
-            db = ".".join(db_parts)
+            db = '.'.join(db_parts)
 
             # Save this for later use.
             self.host = url.host
@@ -91,11 +95,11 @@ class DrillDialect_sadrill(DrillDialect):
             qargs['db'] = db
             if url.username:
                 qargs['drilluser'] = url.username
-                qargs['drillpass'] = ""
+                qargs['drillpass'] = ''
                 if url.password:
                     qargs['drillpass'] = url.password
         except Exception as ex:
-            print("************************************")
-            print("Error in DrillDialect_sadrill.create_connect_args :: ", str(ex))
-            print("************************************")
+            logger.error('could not parse the provided connection url.')
+            raise(ex)
+
         return [], qargs


### PR DESCRIPTION
This is basically a rewrite of _drilldbapi.py.  

1. Streaming query result parsing using ijson.  Clients can start processing rows before the server has finished sending them and no longer need to buffer the entire dataset in memory.
2. Remove Pandas and Numpy which were out of place in this layer.
3. Lots of cleaning up.

This pairs nicely with the streaming JSON serialisation in Drill 1.19 and combined they should make fetching data from Drill to Python a good deal more efficient and reliable, at least for people who didn't go the JDBC or ODBC routes.

Log from a short session where I run `SELECT *` on a remote 17bn record table over a 0.5 Mbit/s link  and start receiving (a steady trickle of) rows in seconds.

```ipython
In [4]: r = engine.execute('select count(*) from dfs.ws.big_table')
INFO:drilldbapi:received Drill query ID 1f211888-cc20-fe6f-69d1-6584c5caa2df.
INFO:drilldbapi:opened a row data stream of 1 columns.

In [5]: next(r)
Out[5]: (17437571247,)

In [6]: r = engine.execute('select * from dfs.ws.big_table')
INFO:drilldbapi:received Drill query ID 1f211838-73df-1506-a74e-f5695f6b0ff5.
INFO:drilldbapi:opened a row data stream of 21 columns.

In [7]: while True:
   ...:     _ = next(r)
   ...:
INFO:drilldbapi:streamed 10000 rows.
INFO:drilldbapi:streamed 20000 rows.
INFO:drilldbapi:streamed 30000 rows.
INFO:drilldbapi:streamed 40000 rows.
```