### PR TITLE
Add an impersonation_target parm to drill+sadrill URLs.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+max_line_length = 80
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 ## [Unreleased]
 
+## [1.1.2] - 2022-03-14
+
+### Changed
+
+- Add an impersonation_target parm to drill+sadrill URLs. When present,
+  this parameter will be converted to a userName property in POSTs made to
+  /query.json.
+
 ## [1.1.1] - 2021-07-28
 
 ### Fixed
 
-- Backwards compatibility with Drill < 1.19, limited to returning
-  all data values as strings. Users not able to upgrade to >= 1.19
-  must implement their own typecasting or use sqlalchemy-drill 0.3.
+- Backwards compatibility with Drill < 1.19, limited to returning all data
+  values as strings. Users not able to upgrade to >= 1.19 must implement their
+  own typecasting or use sqlalchemy-drill 0.3.
 
 ## [1.1.0] - 2021-07-21
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='sqlalchemy_drill',
-      version='1.1.1',
+      version='1.1.2',
       description="Apache Drill for SQLAlchemy",
       long_description=long_description,
       long_description_content_type="text/markdown",
@@ -64,7 +64,7 @@ setup(name='sqlalchemy_drill',
       license='MIT',
       url='https://github.com/JohnOmernik/sqlalchemy-drill',
       download_url='https://github.com/JohnOmernik/sqlalchemy-drill/archive/'
-      '1.1.1.tar.gz',
+      '1.1.2.tar.gz',
       packages=find_packages(),
       include_package_data=True,
       tests_require=['nose >= 0.11'],

--- a/sqlalchemy_drill/__init__.py
+++ b/sqlalchemy_drill/__init__.py
@@ -19,7 +19,7 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 from sqlalchemy.dialects import registry
 
 registry.register("drill", "sqlalchemy_drill.sadrill", "DrillDialect_sadrill")


### PR DESCRIPTION
When present, this parameter will be converted to a userName property in POSTs made to /query.json and that is taken as an inbound impersonation instruction by Drill.