### PR TITLE
Fix a type casting bug causing errors for null dates and times.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+## [1.1.3] - 2022-05-03
+
+### Changed
+
+- Fixed type casting bug which caused queries that returned null date or time
+  values to raise an error in _drilldbapi.py.
+
 ## [1.1.2] - 2022-03-14
 
 ### Changed

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='sqlalchemy_drill',
-      version='1.1.2',
+      version='1.1.3',
       description="Apache Drill for SQLAlchemy",
       long_description=long_description,
       long_description_content_type="text/markdown",
@@ -64,7 +64,7 @@ setup(name='sqlalchemy_drill',
       license='MIT',
       url='https://github.com/JohnOmernik/sqlalchemy-drill',
       download_url='https://github.com/JohnOmernik/sqlalchemy-drill/archive/'
-      '1.1.2.tar.gz',
+      '1.1.3.tar.gz',
       packages=find_packages(),
       include_package_data=True,
       tests_require=['nose >= 0.11'],

--- a/sqlalchemy_drill/__init__.py
+++ b/sqlalchemy_drill/__init__.py
@@ -19,7 +19,7 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = '1.1.2'
+__version__ = '1.1.3'
 from sqlalchemy.dialects import registry
 
 registry.register("drill", "sqlalchemy_drill.sadrill", "DrillDialect_sadrill")

--- a/sqlalchemy_drill/drilldbapi/_drilldbapi.py
+++ b/sqlalchemy_drill/drilldbapi/_drilldbapi.py
@@ -353,9 +353,9 @@ class Connection(object):
         else:
             # Starting in 1.19 the Drill REST API returns UNIX times
             self.typecasters = {
-                'DATE': lambda v: DateFromTicks(v/1000),
-                'TIME': lambda v: TimeFromTicks(v/1000),
-                'TIMESTAMP': lambda v: TimestampFromTicks(v/1000)
+                'DATE': lambda v: DateFromTicks(v),
+                'TIME': lambda v: TimeFromTicks(v),
+                'TIMESTAMP': lambda v: TimestampFromTicks(v)
             }
             logger.debug(
                 'sets up typecasting functions for Drill >= 1.19.'
@@ -585,18 +585,18 @@ def Timestamp(year, month, day, hour=0, minute=0, second=0, microsecond=0,
 
 
 def DateFromTicks(ticks):
-    """Construct an object holding a date value from the given ticks value."""
-    return Date(*gmtime(ticks)[:3])
+    """Construct an object holding a date value from the given Unix time ms."""
+    return Date(*gmtime(ticks/1000)[:3]) if ticks else None
 
 
 def TimeFromTicks(ticks):
-    """Construct an object holding a time value from the given ticks value."""
-    return Time(*gmtime(ticks)[3:6])
+    """Construct an object holding a time value from the given Unix time ms."""
+    return Time(*gmtime(ticks/1000)[3:6]) if ticks else None
 
 
 def TimestampFromTicks(ticks):
-    """Construct an object holding a timestamp from the given ticks value."""
-    return Timestamp(*gmtime(ticks)[:6])
+    """Construct an object holding a timestamp from the given Unix time ms."""
+    return Timestamp(*gmtime(ticks/1000)[:6]) if ticks else None
 
 
 class Binary(bytes):


### PR DESCRIPTION
Fixes a type casting bug which caused queries that returned null date or time values to raise an error in _drilldbapi.py. Github issue #76.