### PR TITLE
Add error message to DatabaseError output

### DIFF
--- a/sqlalchemy_drill/drilldbapi/_drilldbapi.py
+++ b/sqlalchemy_drill/drilldbapi/_drilldbapi.py
@@ -91,23 +91,28 @@ class Cursor(object):
     def _report_query_state(self):
         md = self.result_md
         query_state = md.get('queryState', None)
+        exception = md.get(
+                    'exception',
+                    'No exception returned.'
+                )
+        error_message = md.get(
+            'errorMessage',
+            'No error message is returned (which most likely means that ' \
+            'drill.exec.http.rest.errors.verbose is set to false.)'
+        )
+        stack_trace = md.get('stackTrace', 'No stack trace returned.')
+
         logger.info(
             f'received final query state {query_state}.'
         )
 
         if query_state != 'COMPLETED':
-            logger.warning(
-                md.get(
-                    'exception',
-                    'No exception returned, c.f. drill.exec.http.rest.errors.verbose.'
-                )
-            )
-            logger.warning(
-                md.get('errorMessage', 'No error message returned.'))
-            logger.warning(md.get('stackTrace', 'No stack trace returned.'))
+            logger.warning(exception)
+            logger.warning(error_message)
+            logger.warning(stack_trace)
 
             raise DatabaseError(
-                f'Final Drill query state is {query_state}',
+                f'Final Drill query state is {query_state}. {error_message}',
                 None
             )
 


### PR DESCRIPTION
Drill 1.19 omits the error message in REST API by default, which is overwritable by setting `http.rest.errors.verbose` to `true`. Some non-technical users may benefit from having an error message in Superset UI in case there is a database error or their SQL query is corrupted, which this PR implements. If no error message is provided, it is also useful to know how to overwrite that behavior as it is not easily searchable online.