### PR TITLE
Fix wrongly delegated import_dbapi method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='sqlalchemy_drill',
-      version='1.1.6',
+      version='1.1.7',
       description="Apache Drill for SQLAlchemy",
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/sqlalchemy_drill/__init__.py
+++ b/sqlalchemy_drill/__init__.py
@@ -19,7 +19,7 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = '1.1.6'
+__version__ = '1.1.7'
 from sqlalchemy.dialects import registry
 
 registry.register("drill", "sqlalchemy_drill.sadrill", "DrillDialect_sadrill")

--- a/sqlalchemy_drill/sadrill.py
+++ b/sqlalchemy_drill/sadrill.py
@@ -71,7 +71,7 @@ class DrillDialect_sadrill(DrillDialect):
     @classmethod
     def dbapi(cls):
         """Deprecated in SQLAlchemy, retained for backwards compatibility."""
-        DrillCompiler_sadrill.import_dbapi()
+        DrillDialect_sadrill.import_dbapi()
 
     def create_connect_args(self, url, **kwargs):
         url_port = url.port or 8047


### PR DESCRIPTION
The import_dbapi method should be called on DrillDialect_sadrill class not the compiler one.

Fixes: #92