### PR TITLE
Fix: Adding Mongo dataset

### DIFF
--- a/sqlalchemy_drill/base.py
+++ b/sqlalchemy_drill/base.py
@@ -419,7 +419,7 @@ class DrillDialect(default.DefaultDialect):
             for row in column_metadata:
 
                 #  Get rid of precision information in data types
-                data_type = row[1].lower()
+                data_type = str(row[1]).lower()
                 pattern = r"[a-zA-Z]+\(\d+, \d+\)"
 
                 if re.search(pattern, data_type):
@@ -445,8 +445,8 @@ class DrillDialect(default.DefaultDialect):
         for row in query_results:
             column = {
                 "name": row[0],
-                "type": self.get_data_type(row[1].lower()),
-                "longType": self.get_data_type(row[1].lower())
+                "type": self.get_data_type(str(row[1]).lower()),
+                "longType": self.get_data_type(str(row[1]).lower())
             }
             result.append(column)
         logging.debug(result)

--- a/sqlalchemy_drill/drilldbapi/_drilldbapi.py
+++ b/sqlalchemy_drill/drilldbapi/_drilldbapi.py
@@ -493,7 +493,7 @@ def connect(host: str,
 
     conn = Connection(host, port, proto, impersonation_target, session)
     if db is not None:
-        conn.submit_query(f'USE {db.replace("%2F", ".")}')
+        conn.submit_query(f'USE {db}')
 
     return conn
 

--- a/sqlalchemy_drill/drilldbapi/_drilldbapi.py
+++ b/sqlalchemy_drill/drilldbapi/_drilldbapi.py
@@ -493,7 +493,7 @@ def connect(host: str,
 
     conn = Connection(host, port, proto, impersonation_target, session)
     if db is not None:
-        conn.submit_query(f'USE {db}')
+        conn.submit_query(f'USE {db.replace("%2F", ".")}')
 
     return conn
 


### PR DESCRIPTION
Adding a MongoDB based dataset in Apache superset results in a typecast error, fixed by ensuring rows are strings.

https://github.com/apache/superset/pull/33956 uses this in order to have MongoDb + SqlAlchemyDrill + Superset working properly to add datasets