### PR TITLE
Data Type Bug Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ lib64/
 parts/
 sdist/
 var/
+venv/
 *.egg-info/
 .installed.cfg
 *.egg
@@ -94,3 +95,4 @@ ENV/
 
 # Python IDE
 .idea/
+/token.txt

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,115 @@
+[MAIN]
+# Analyse import fallback blocks
+analyse-fallback-blocks=no
+
+# Load and enable all available extensions
+load-plugins=pylint.extensions.docparams
+
+# Files or directories to ignore
+ignore=CVS,.git,__pycache__,build,dist,*.egg-info
+
+# Python version
+py-version=3.10
+
+# Jobs to run in parallel (0 = auto-detect)
+jobs=0
+
+[MESSAGES CONTROL]
+# Disable specific messages
+disable=
+    C0114,  # missing-module-docstring
+    C0115,  # missing-class-docstring
+    C0116,  # missing-function-docstring
+    C0301,  # line-too-long (handled by formatter)
+    C0103,  # invalid-name (allow single letter variables, non-standard names)
+    R0801,  # duplicate-code
+    R0903,  # too-few-public-methods
+    R0913,  # too-many-arguments
+    R0914,  # too-many-locals
+    R0915,  # too-many-statements
+    R0902,  # too-many-instance-attributes
+    R0904,  # too-many-public-methods
+    R0912,  # too-many-branches
+    W0212,  # protected-access (common in SQLAlchemy dialects)
+    W0223,  # abstract-method (SQLAlchemy dialect methods)
+    W0613,  # unused-argument (required by interface)
+    W0703,  # broad-except
+    W1203,  # logging-fstring-interpolation
+    E1101,  # no-member (false positives with dynamic attributes)
+
+[FORMAT]
+# Maximum line length
+max-line-length=120
+
+# Expected indentation
+indent-string='    '
+
+[BASIC]
+# Good variable names
+good-names=i,j,k,v,f,ex,db,q,kw,fn,id,pk,fk
+
+# Naming style
+function-naming-style=snake_case
+variable-naming-style=snake_case
+class-naming-style=PascalCase
+const-naming-style=UPPER_CASE
+module-naming-style=snake_case
+
+[DESIGN]
+# Maximum number of arguments for function / method
+max-args=10
+
+# Maximum number of locals for function / method body
+max-locals=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=15
+
+# Maximum number of statements in function / method body
+max-statements=60
+
+# Maximum number of attributes for a class
+max-attributes=15
+
+[IMPORTS]
+# Allow wildcard imports from these modules
+allow-wildcard-with-all=no
+
+# Deprecated modules
+deprecated-modules=optparse
+
+[LOGGING]
+# Logging format style
+logging-format-style=new
+
+[TYPECHECK]
+# List of members which are set dynamically
+generated-members=
+    sqlalchemy.*,
+    types.*
+
+# Ignore missing members for these classes
+ignored-classes=
+    SQLObject,
+    optparse.Values,
+    thread._local,
+    _thread._local
+
+[SIMILARITIES]
+# Minimum lines number of a similarity
+min-similarity-lines=6
+
+# Ignore comments when computing similarities
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities
+ignore-imports=yes
+
+# Allow DB-API 2.0 required function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$|^(Date|Time|Timestamp|DateFromTicks|TimeFromTicks|TimestampFromTicks|Binary)$

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with io.open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='sqlalchemy_drill',
-      version='1.1.9',
+      version='1.1.10',
       description="Apache Drill for SQLAlchemy",
       long_description=long_description,
       long_description_content_type="text/markdown",
@@ -64,7 +64,7 @@ setup(name='sqlalchemy_drill',
       license='MIT',
       url='https://github.com/JohnOmernik/sqlalchemy-drill',
       download_url='https://github.com/JohnOmernik/sqlalchemy-drill/archive/'
-      '1.1.9.tar.gz',
+      '1.1.10.tar.gz',
       packages=find_packages(),
       include_package_data=True,
       tests_require=['nose >= 0.11'],

--- a/sqlalchemy_drill/__init__.py
+++ b/sqlalchemy_drill/__init__.py
@@ -19,7 +19,7 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-__version__ = '1.1.9'
+__version__ = '1.1.10'
 from sqlalchemy.dialects import registry
 
 registry.register("drill", "sqlalchemy_drill.sadrill", "DrillDialect_sadrill")

--- a/sqlalchemy_drill/drilldbapi/_drilldbapi.py
+++ b/sqlalchemy_drill/drilldbapi/_drilldbapi.py
@@ -24,8 +24,45 @@ from ijson.common import ObjectBuilder
 from requests import Session, Response
 
 from . import api_globals
-from .api_exceptions import (AuthError, ConnectionClosedException, CursorClosedException,
-                             DatabaseError, ProgrammingError)
+from .api_exceptions import (
+    AuthError,
+    ConnectionClosedException,
+    CursorClosedException,
+    DatabaseError,
+    DrillWarning,
+    Error,
+    IntegrityError,
+    InterfaceError,
+    InternalError,
+    NotSupportedError,
+    OperationalError,
+    ProgrammingError,
+)
+
+# DB-API 2.0 requires Warning to be exported at module level
+# We renamed it to DrillWarning to avoid shadowing built-in, but alias it here
+Warning = DrillWarning  # noqa: A001  # pylint: disable=redefined-builtin
+
+# Explicit exports for DB-API 2.0 compliance
+__all__ = [
+    # Module globals
+    'apilevel', 'threadsafety', 'paramstyle',
+    # Classes
+    'Connection', 'Cursor',
+    # Functions
+    'connect',
+    # Type objects
+    'STRING', 'BINARY', 'NUMBER', 'DATETIME', 'ROWID',
+    'BOOL', 'SMALLINT', 'INTEGER', 'LONG', 'FLOAT', 'NUMERIC',
+    'DATE', 'TIME', 'TIMESTAMP', 'INTERVAL',
+    # Type constructors
+    'Date', 'Time', 'Timestamp', 'DateFromTicks', 'TimeFromTicks', 'TimestampFromTicks', 'Binary',
+    # Exceptions (DB-API 2.0 required)
+    'Warning', 'Error', 'InterfaceError', 'DatabaseError', 'OperationalError',
+    'IntegrityError', 'InternalError', 'ProgrammingError', 'NotSupportedError',
+    # Additional exceptions
+    'AuthError', 'CursorClosedException', 'ConnectionClosedException',
+]
 
 apilevel = '2.0'
 threadsafety = 3

--- a/sqlalchemy_drill/drilldbapi/api_exceptions.py
+++ b/sqlalchemy_drill/drilldbapi/api_exceptions.py
@@ -1,125 +1,91 @@
 # -*- coding: utf-8 -*-
+"""DB-API 2.0 compliant exceptions for Drill."""
 
 
-class Warning(Exception):
-    pass
+class DrillWarning(Exception):
+    """DB-API Warning - renamed to avoid shadowing built-in Warning."""
 
 
 class Error(Exception):
+    """Base class for all Drill DB-API errors."""
+
     def __init__(self, message, httperror):
+        super().__init__(message)
         self.message = message
         self.httperror = httperror
 
 
 class AuthError(Error):
+    """Authentication error."""
 
     def __str__(self):
-        return repr(
-            "{msg} {type} {err}".format(
-                msg=self.message,
-                type="Authentication Error: Invalid User/Pass:",
-                err=self.httperror,
-            )
-        )
+        return repr(f"{self.message} Authentication Error: Invalid User/Pass: {self.httperror}")
 
 
 class DatabaseError(Error):
+    """Database error."""
 
     def __str__(self):
-        return repr(
-            "{msg} {type} {err}".format(
-                msg=self.message,
-                type="HTTP ERROR:",
-                err=self.httperror,
-            )
-        )
+        return repr(f"{self.message} HTTP ERROR: {self.httperror}")
 
 
 class ProgrammingError(Error):
+    """Programming error."""
 
     def __str__(self):
-        return repr(
-            "{msg} {type} {err}".format(
-                msg=self.message,
-                type="HTTP ERROR:",
-                err=self.httperror,
-            )
-        )
+        return repr(f"{self.message} HTTP ERROR: {self.httperror}")
 
 
 class InterfaceError(Error):
+    """Interface error."""
 
     def __str__(self):
-        return repr(
-            "{msg} {type} {err}".format(
-                msg=self.message,
-                type="HTTP ERROR:",
-                err=self.httperror,
-            )
-        )
+        return repr(f"{self.message} HTTP ERROR: {self.httperror}")
 
 
 class OperationalError(Error):
+    """Operational error."""
 
     def __str__(self):
-        return repr(
-            "{msg} {type} {err}".format(
-                msg=self.message,
-                type="HTTP ERROR:",
-                err=self.httperror,
-            )
-        )
+        return repr(f"{self.message} HTTP ERROR: {self.httperror}")
 
 
 class IntegrityError(Error):
+    """Integrity error."""
 
     def __str__(self):
-        return repr(
-            "{msg} {type} {err}".format(
-                msg=self.message,
-                type="HTTP ERROR:",
-                err=self.httperror,
-            )
-        )
+        return repr(f"{self.message} HTTP ERROR: {self.httperror}")
 
 
 class InternalError(Error):
+    """Internal error."""
 
     def __str__(self):
-        return repr(
-            "{msg} {type} {err}".format(
-                msg=self.message,
-                type="HTTP ERROR:",
-                err=self.httperror,
-            )
-        )
+        return repr(f"{self.message} HTTP ERROR: {self.httperror}")
 
 
 class NotSupportedError(Error):
+    """Not supported error."""
 
     def __str__(self):
-        return repr(
-            "{msg} {type} {err}".format(
-                msg=self.message,
-                type="HTTP ERROR:",
-                err=self.httperror,
-            )
-        )
+        return repr(f"{self.message} HTTP ERROR: {self.httperror}")
 
 
 class CursorClosedException(Error):
+    """Cursor closed exception."""
 
     def __init__(self, message):
-        self.message = message
+        super().__init__(message, None)
 
     def __str__(self):
         return repr(self.message)
 
 
 class ConnectionClosedException(Error):
+    """Connection closed exception."""
 
     def __init__(self, message):
-        self.message = message
+        super().__init__(message, None)
 
     def __str__(self):
         return repr(self.message)

--- a/sqlalchemy_drill/drilldbapi/api_globals.py
+++ b/sqlalchemy_drill/drilldbapi/api_globals.py
@@ -5,4 +5,3 @@ _HEADER = {'Content-Type': 'application/json'}
 _PAYLOAD = {'queryType': 'SQL', 'query': None}
 _LOGIN = {'j_username': None, 'j_password': None}
 _PROGRESS_LOG_N = 10_000
-

--- a/sqlalchemy_drill/odbc.py
+++ b/sqlalchemy_drill/odbc.py
@@ -21,31 +21,36 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import pyodbc
 import logging
+
+import pyodbc
+
 from .base import DrillDialect, DrillCompiler_sadrill
+
+logger = logging.getLogger(__name__)
 
 
 class DrillDialect_odbc(DrillDialect):
     statement_compiler = DrillCompiler_sadrill
-    logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.INFO)
 
-    def create_connect_args(self, url):
-        if url is not None:
-            params = super(DrillDialect, self).create_connect_args(url)[1]
+    def create_connect_args(self, url, **kwargs):
+        if url is None:
+            return [], {}
 
-            # Convert URL query parameters to ODBC connection string
-            connection_string = ";".join("{}={}".format(k, v) for (k, v) in params.items())
+        params = super(DrillDialect, self).create_connect_args(url)[1]
 
-            cargs = (connection_string, )
-            cparams = {
-                "autocommit": True,  # Drill ODBC driver does not support transactions
-            }
+        # Convert URL query parameters to ODBC connection string
+        connection_string = ";".join(f"{k}={v}" for k, v in params.items())
 
-            logging.info("Cargs:" + str(cargs))
-            logging.info("Cparams" + str(cparams))
+        cargs = (connection_string,)
+        cparams = {
+            "autocommit": True,  # Drill ODBC driver does not support transactions
+        }
 
-            return (cargs, cparams)
+        logger.info(f"Cargs: {cargs}")
+        logger.info(f"Cparams: {cparams}")
+
+        return cargs, cparams
 
     @classmethod
     def dbapi(cls):

--- a/test/dbapi20.py
+++ b/test/dbapi20.py
@@ -18,7 +18,7 @@ than just syntactic limitations, entire test methods are overriden in test_dbapi
     -- Ian Bicking
 '''
 
-__version__ = '1.15.0-drill'
+__version__ = '1.22.0-drill'
 
 import unittest
 import time


### PR DESCRIPTION
  This PR addresses multiple bugs and code quality issues across the sqlalchemy-drill codebase.

  Bug Fixes

  - URL encoding issue: Fixed malformed USE queries when Superset URL-encodes schema paths (e.g., %2F for /). Added urllib.parse.unquote() to properly decode database paths before
  processing.
  - Data type detection: Fixed issue where all column types were returning as UserDefinedType:
    - Expanded _type_map with additional Drill types: varbinary, numeric, float, float4, real, tinyint, char, character, string, null, struct, array
    - Fixed extraction of type names from DBAPITypeObject.values instead of converting the object to string
    - Improved precision stripping to handle all formats (e.g., varchar(100), decimal(10,2))
  - Splunk schema support: Added Splunk to the list of plugins with dynamic schemas that require querying data directly to retrieve column metadata (similar to MongoDB handling)
  - Streaming results option: Added stream_results connection parameter to allow disabling HTTP streaming, which can work around certain Drill REST API bugs with array columns
  - Removed obsolete imports: Removed references to DefaultCompiler which no longer exists in modern SQLAlchemy versions